### PR TITLE
Add option to include dependabot issues/PRs.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 
 use anyhow::{bail, Context, Result};
 use chrono::{Date, DateTime, Local, NaiveDate, SecondsFormat, TimeZone, Utc};
+use clap::{Parser, Subcommand};
 use reqwest::blocking::{Client, Response};
 use reqwest::header;
 use reqwest::header::{HeaderMap, USER_AGENT};
@@ -16,7 +17,6 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::{thread, time};
-use clap::{Parser, Subcommand};
 
 static RIB_AGENT: &'static str = "ribbot (Rust-in-Blockchain; Aimeedeer/ribbot; aimeez@pm.me)";
 static CONFIG: &'static str = include_str!("rib-config.toml");
@@ -131,7 +131,6 @@ fn fetch_pulls(config: &Config, opts: &PullCmdOpts) -> Result<()> {
                 calls, new_calls
             );
             println!("");
-
         }
     }
 
@@ -174,25 +173,14 @@ struct GhPullWithComments {
 #[derive(Deserialize, Debug)]
 struct GhComments {}
 
-fn do_smoke_test(
-    client: &mut GhClient,
-    project: &Project,
-    opts: &PullCmdOpts,
-) -> Result<()> {
+fn do_smoke_test(client: &mut GhClient, project: &Project, opts: &PullCmdOpts) -> Result<()> {
     println!("#### [{}]({})", project.name, project.url);
     println!("");
 
     for repo in &project.repos {
-        let url = format!(
-            "https://api.github.com/repos/{}/pulls",
-            repo
-        );
+        let url = format!("https://api.github.com/repos/{}/pulls", repo);
 
-        let res = do_gh_api_request(
-            client,
-            &url,
-            &opts.oauth_token
-        );
+        let res = do_gh_api_request(client, &url, &opts.oauth_token);
 
         match res {
             Ok(_) => {
@@ -434,7 +422,7 @@ fn get_merged_pulls(
                     }
                     if let Some(merged_at) = pr.merged_at.clone() {
                         if merged_at < begin {
-                          println!("<!-- discard too old: {} -->", pr.html_url);
+                            println!("<!-- discard too old: {} -->", pr.html_url);
                             false
                         } else if merged_at >= end {
                             println!("<!-- discard too new: {} -->", pr.html_url);
@@ -549,7 +537,7 @@ fn do_gh_api_request(
                 delay_ms(5000);
                 continue;
             }
-            _ => { }
+            _ => {}
         }
 
         let limits = get_rate_limit_values(&headers)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -703,8 +703,8 @@ fn print_project(
     println!();
 
     let dependabot_query_param = match opts.include_dependabot {
-        true => " -author:app/dependabot",
-        false => "",
+        true => "",
+        false => " -author:app/dependabot",
     };
 
     // print PR details


### PR DESCRIPTION
Add an option, `--include-dependabot`, that allows including issues and PRs created by dependabot. By default, this is disabled as dependabot commits aren't particularly interesting.

This allows projects that don't use dependabot to be compared more evenly against projects that do use dependabot, which can greatly skew the number of PRs without actually being a good signal of activity.

---

To illustrate results, here's the current stats from [June's newsletter](https://rustinblockchain.org/newsletters/rib-newsletter-37/) for the top 5 projects:

- [Parity](https://github.com/paritytech): 557 merged PRs, 152 closed issues, 130 open issues
- [Solana](https://github.com/solana-labs/solana): 501 merged PRs, 95 closed issues, 103 open issues
- [Sui](https://github.com/MystenLabs): 343 merged PRs, 155 closed issues, 140 open issues
- [Fuel](https://github.com/FuelLabs): 339 merged PRs, 214 closed issues, 180 open issues
- [Aptos](https://github.com/aptos-labs): 290 merged PRs, 81 closed issues, 32 open issues

And with dependabot issues/PRs filtered out and re-sorted by PRs merged:

- [Solana](https://github.com/solana-labs/solana): 488 merged PRs, 95 closed issues, 98 open issues
- [Parity](https://github.com/paritytech): 428 merged PRs, 152 closed issues, 125 open issues
- [Fuel](https://github.com/FuelLabs): 339 merged PRs, 214 closed issues, 160 open issues
- [Sui](https://github.com/MystenLabs): 291 merged PRs, 155 closed issues, 138 open issues
- [Aptos](https://github.com/aptos-labs): 290 merged PRs, 81 closed issues, 31 open issues

---

Meant to be merged into/on top of #8, but GitHub doesn't seem to have a way of doing that from a fork. Actual diff: https://github.com/adlerjohn/ribbot/compare/adlerjohn/fmt...adlerjohn/dependabot-ignore